### PR TITLE
Update filtering default values to focus on smaller channels

### DIFF
--- a/backend/channel-filter.js
+++ b/backend/channel-filter.js
@@ -76,8 +76,8 @@ export function hasGoodGrowthRate(growthRate, minGrowthRate = 10) {
 export function filterChannel(channelData, firstVideo = null, options = {}) {
   const {
     monthsThreshold = 3,
-    minSubscribers = 1000,
-    maxSubscribers = 1000000,
+    minSubscribers = 500,
+    maxSubscribers = 1000,
     minVideos = 5,
     minGrowthRate = 10
   } = options;

--- a/backend/collect-channels.js
+++ b/backend/collect-channels.js
@@ -23,9 +23,9 @@ dotenv.config();
 const COLLECTION_CONFIG = {
   keywordCount: 10,         // 使用するキーワード数（クォータ効率化）
   videosPerKeyword: 25,     // キーワードあたりの動画検索数（クォータ効率化）
-  monthsThreshold: 6,       // 何ヶ月以内のチャンネルを対象とするか
-  minSubscribers: 100,      // 最小登録者数（大幅緩和）
-  maxSubscribers: 1000000,  // 最大登録者数（拡大）
+  monthsThreshold: 3,       // 何ヶ月以内のチャンネルを対象とするか
+  minSubscribers: 500,      // 最小登録者数
+  maxSubscribers: 1000,     // 最大登録者数
   minVideos: 2,             // 最小動画数（緩和）
   minGrowthRate: 3,         // 最小成長率（緩和）
   maxChannelsPerRun: 500,   // 1回の実行で処理する最大チャンネル数（大幅増加）

--- a/backend/enhanced-collection.js
+++ b/backend/enhanced-collection.js
@@ -26,11 +26,11 @@ const ENHANCED_CONFIG = {
   // 基本設定
   keywordCount: 30,           // より多くのキーワードを使用
   videosPerKeyword: 50,       // キーワードあたりの動画検索数
-  monthsThreshold: 12,        // 1年間のチャンネルを対象
+  monthsThreshold: 3,         // 3ヶ月間のチャンネルを対象
   
   // 条件緩和
-  minSubscribers: 50,         // 最小登録者数をさらに緩和
-  maxSubscribers: 2000000,    // 最大登録者数を拡大
+  minSubscribers: 500,        // 最小登録者数
+  maxSubscribers: 1000,       // 最大登録者数
   minVideos: 1,               // 最小動画数を大幅緩和
   minGrowthRate: 1,           // 最小成長率を大幅緩和
   

--- a/backend/smart-collect.js
+++ b/backend/smart-collect.js
@@ -189,9 +189,9 @@ async function smartCollection() {
     
     // 8. フィルタリング
     const filteredChannels = filterChannels(channelsWithDetails, {
-      monthsThreshold: 6,
-      minSubscribers: 100,
-      maxSubscribers: 1000000,
+      monthsThreshold: 3,
+      minSubscribers: 500,
+      maxSubscribers: 1000,
       minVideos: 2,
       minGrowthRate: 3
     });

--- a/backend/user-batch-collector.js
+++ b/backend/user-batch-collector.js
@@ -171,8 +171,8 @@ async function collectForSingleUser(user, logPrefix) {
       videosPerKeyword: user.settings.videosPerKeyword || 40,
       maxChannelsPerRun: user.settings.maxChannelsPerRun || 150,
       monthsThreshold: user.settings.monthsThreshold || 3,
-      minSubscribers: user.settings.minSubscribers || 1000,
-      maxSubscribers: user.settings.maxSubscribers || 500000,
+      minSubscribers: user.settings.minSubscribers || 500,
+      maxSubscribers: user.settings.maxSubscribers || 1000,
       minVideos: user.settings.minVideos || 5,
       minGrowthRate: user.settings.minGrowthRate || 10
     };

--- a/frontend/src/components/Settings.jsx
+++ b/frontend/src/components/Settings.jsx
@@ -20,8 +20,8 @@ const Settings = () => {
     
     // フィルタリング設定
     monthsThreshold: 3,
-    minSubscribers: 1000,
-    maxSubscribers: 500000,
+    minSubscribers: 500,
+    maxSubscribers: 1000,
     minVideos: 5,
     minGrowthRate: 10,
     


### PR DESCRIPTION
## Summary
- Update default subscriber range from 1000-500000 to 500-1000 to focus on smaller, emerging channels
- Reduce channel age threshold from 6 months to 3 months for more recent discoveries
- Update defaults consistently across all collection scripts and frontend components
- Maintain full user configurability through existing Settings UI

## Changes Made
- **Frontend**: Updated Settings.jsx default values
- **Backend**: Updated default values in:
  - `channel-filter.js` - Core filtering function defaults
  - `collect-channels.js` - Main collection script config
  - `smart-collect.js` - Smart collection filtering
  - `enhanced-collection.js` - Enhanced collection config
  - `user-batch-collector.js` - User-specific collection defaults

## Test Plan
- [ ] Verify Settings UI shows new default values for new users
- [ ] Test that existing user settings are preserved
- [ ] Run collection scripts to ensure filtering works with new defaults
- [ ] Confirm user can still override defaults through Settings

🤖 Generated with [Claude Code](https://claude.ai/code)